### PR TITLE
Adding important information on Webhook config

### DIFF
--- a/pull-request-evaluator/TLDR.md
+++ b/pull-request-evaluator/TLDR.md
@@ -148,3 +148,4 @@ gcloud builds submit . --config=./cloudbuild.yaml --region=$MY_LOCATION --projec
 
 Point your Git Webhook call to the **Cloud Run** URL `/webhook`.  
 Don´t forget that you need to use the same **WEBHOOK SECRET** otherwise the call will not be authorized.
+The **Content type** should be set to **application/json** for the webhook call.

--- a/pull-request-evaluator/lib/github-webhook/authenticate.js
+++ b/pull-request-evaluator/lib/github-webhook/authenticate.js
@@ -27,9 +27,9 @@ const envHelper = require('../config/env');
 
 /* sign received payload to compare */
 function signPayload(data) {
-    const buffer = Buffer.from(data, 'utf8')
+    const buffer = Buffer.from(data, 'utf8');
     let secret = envHelper.getWebhookSecret();
-    return 'sha1=' + crypto.createHmac('sha1', secret).update(buffer).digest('hex')
+    return 'sha1=' + crypto.createHmac('sha1', secret).update(buffer).digest('hex');
 }
 
 module.exports.signPayload = signPayload;


### PR DESCRIPTION
The webhook payload should always be application/json.